### PR TITLE
Add option to show current-year citations in the menu bar and refine Settings action placement

### DIFF
--- a/Sources/CiteBar/CitationManager.swift
+++ b/Sources/CiteBar/CitationManager.swift
@@ -102,7 +102,13 @@ import UserNotifications
                 }
                 
                 // Store the record
-                let record = CitationRecord(profileId: profile.id, citationCount: metrics.citationCount, hIndex: metrics.hIndex, i10Index: metrics.i10Index)
+                let record = CitationRecord(
+                    profileId: profile.id,
+                    citationCount: metrics.citationCount,
+                    hIndex: metrics.hIndex,
+                    i10Index: metrics.i10Index,
+                    citationsByYear: metrics.citationsByYear
+                )
                 await storageManager.saveCitationRecord(record)
                 
                 // Calculate recent growth and baseline days
@@ -112,7 +118,12 @@ import UserNotifications
                 updatedProfile.recentGrowthDays = growthSummary?.baselineDays
                 
                 // Only add the updated profile with growth data to results
-                results[updatedProfile] = ProfileMetrics(citationCount: metrics.citationCount, hIndex: metrics.hIndex, i10Index: metrics.i10Index)
+                results[updatedProfile] = ProfileMetrics(
+                    citationCount: metrics.citationCount,
+                    hIndex: metrics.hIndex,
+                    i10Index: metrics.i10Index,
+                    citationsByYear: metrics.citationsByYear
+                )
 
                 AppLog.debug("Successfully fetched \(metrics.citationCount) citations for \(profile.name)")
                 if let hIndex = metrics.hIndex {
@@ -120,6 +131,13 @@ import UserNotifications
                 }
                 if let i10Index = metrics.i10Index {
                     AppLog.debug("i10-index for \(profile.name): \(i10Index)")
+                }
+                if let citationsByYear = metrics.citationsByYear {
+                    let currentYear = Calendar.current.component(.year, from: Date())
+                    let currentYearCitations = citationsByYear[currentYear] ?? 0
+                    AppLog.debug("Current-year citations for \(profile.name) (\(currentYear)): \(currentYearCitations)")
+                } else {
+                    AppLog.debug("Current-year citations unavailable for \(profile.name) (yearly histogram parse failed)")
                 }
                 if let growthSummary = growthSummary {
                     let growth = growthSummary.growth
@@ -293,6 +311,7 @@ import UserNotifications
     private func parseScholarMetrics(from html: String) throws -> ScholarMetrics {
         do {
             let doc = try SwiftSoup.parse(html)
+            let citationsByYear = parseCitationsByYear(from: doc)
             
             // Try multiple selectors for the statistics table
             let possibleSelectors = [
@@ -308,7 +327,12 @@ import UserNotifications
                         let metrics = try parseScholarTable(table)
                         if metrics.citationCount > 0 {
                             AppLog.debug("Successfully parsed from table - Citations: \(metrics.citationCount), h-index: \(metrics.hIndex ?? -1), i10-index: \(metrics.i10Index ?? -1)")
-                            return metrics
+                            return ScholarMetrics(
+                                citationCount: metrics.citationCount,
+                                hIndex: metrics.hIndex,
+                                i10Index: metrics.i10Index,
+                                citationsByYear: citationsByYear
+                            )
                         }
                     }
                 }
@@ -342,7 +366,12 @@ import UserNotifications
                     let metrics = parseScholarCellArray(elementsArray)
                     if metrics.citationCount > 0 {
                         AppLog.debug("Successfully parsed from cells - Citations: \(metrics.citationCount), h-index: \(metrics.hIndex ?? -1), i10-index: \(metrics.i10Index ?? -1)")
-                        return metrics
+                        return ScholarMetrics(
+                            citationCount: metrics.citationCount,
+                            hIndex: metrics.hIndex,
+                            i10Index: metrics.i10Index,
+                            citationsByYear: citationsByYear
+                        )
                     }
                 }
             }
@@ -353,7 +382,7 @@ import UserNotifications
                 let text = try element.text()
                 if let number = extractValidCitationCount(from: text) {
                     AppLog.debug("Found potential citation count in fallback: \(text) -> \(number)")
-                    return ScholarMetrics(citationCount: number, hIndex: nil, i10Index: nil)
+                    return ScholarMetrics(citationCount: number, hIndex: nil, i10Index: nil, citationsByYear: citationsByYear)
                 }
             }
             
@@ -364,6 +393,50 @@ import UserNotifications
             AppLog.error("HTML parsing error: \(error)")
             throw CitationError.parsingError
         }
+    }
+
+    private func parseCitationsByYear(from doc: Document) -> [Int: Int]? {
+        do {
+            let yearElements = Array(try doc.select(".gsc_g_t"))
+            let barValueElements = Array(try doc.select(".gsc_g_a .gsc_g_al"))
+            let pairCount = min(yearElements.count, barValueElements.count)
+
+            guard pairCount > 0 else {
+                return nil
+            }
+
+            var citationsByYear: [Int: Int] = [:]
+            for index in 0..<pairCount {
+                let yearText = try yearElements[index].text()
+                let valueText = try barValueElements[index].text()
+
+                guard let year = parseYearLabel(from: yearText),
+                      let citations = extractNumber(from: valueText) else {
+                    continue
+                }
+
+                citationsByYear[year] = max(0, citations)
+            }
+
+            if citationsByYear.isEmpty {
+                return nil
+            }
+
+            AppLog.debug("Parsed citation histogram for \(citationsByYear.count) years")
+            return citationsByYear
+        } catch let error as Exception {
+            AppLog.debug("Citation histogram parsing failed: \(error)")
+            return nil
+        } catch {
+            AppLog.debug("Citation histogram parsing failed: \(error)")
+            return nil
+        }
+    }
+
+    private func parseYearLabel(from text: String) -> Int? {
+        guard let year = extractNumber(from: text) else { return nil }
+        guard year >= 1900 && year <= 2100 else { return nil }
+        return year
     }
     
     private func parseScholarTable(_ table: Element) throws -> ScholarMetrics {
@@ -539,7 +612,12 @@ import UserNotifications
                         var updatedProfile = profile
                         updatedProfile.recentGrowth = growthSummary?.growth
                         updatedProfile.recentGrowthDays = growthSummary?.baselineDays
-                        currentData[updatedProfile] = ProfileMetrics(citationCount: latestRecord.citationCount, hIndex: latestRecord.hIndex, i10Index: latestRecord.i10Index)
+                        currentData[updatedProfile] = ProfileMetrics(
+                            citationCount: latestRecord.citationCount,
+                            hIndex: latestRecord.hIndex,
+                            i10Index: latestRecord.i10Index,
+                            citationsByYear: latestRecord.citationsByYear
+                        )
 
                         AppLog.debug("Loaded historical data for \(profile.name): \(latestRecord.citationCount) citations")
                         if let hIndex = latestRecord.hIndex {
@@ -547,6 +625,11 @@ import UserNotifications
                         }
                         if let i10Index = latestRecord.i10Index {
                             AppLog.debug("Historical i10-index for \(profile.name): \(i10Index)")
+                        }
+                        if let citationsByYear = latestRecord.citationsByYear {
+                            let currentYear = Calendar.current.component(.year, from: Date())
+                            let currentYearCitations = citationsByYear[currentYear] ?? 0
+                            AppLog.debug("Historical current-year citations for \(profile.name) (\(currentYear)): \(currentYearCitations)")
                         }
                         if let growthSummary = growthSummary {
                             let growth = growthSummary.growth

--- a/Sources/CiteBar/MenuBarManager.swift
+++ b/Sources/CiteBar/MenuBarManager.swift
@@ -111,7 +111,7 @@ import Cocoa
             let sortedProfiles = citations.keys.sorted { $0.sortOrder < $1.sortOrder }
             if let primaryProfile = sortedProfiles.first,
                let metrics = citations[primaryProfile] {
-                updateMenuBarWithCount(metrics.citationCount)
+                updateMenuBarWithMetrics(metrics)
             } else {
                 applyStatusIcon(
                     symbolName: "book.circle",
@@ -222,13 +222,31 @@ import Cocoa
             // Add citation count as sub-item
             let countText: String
             let countIcon: String
+            var totalSummaryText: String?
             if metrics.citationCount == -1 {
                 countText = "    Loading citations..."
                 countIcon = "arrow.clockwise"
             } else {
-                let formattedCount = NumberFormatter.localizedString(from: NSNumber(value: metrics.citationCount), number: .decimal)
-                countText = "    \(formattedCount) citations"
-                countIcon = "book.closed"
+                let formattedTotal = NumberFormatter.localizedString(from: NSNumber(value: metrics.citationCount), number: .decimal)
+                let currentYear = Calendar.current.component(.year, from: Date())
+                switch settingsManager.settings.menuBarPrimaryMetric {
+                case .totalCitations:
+                    countText = "    \(formattedTotal) citations"
+                    countIcon = "book.closed"
+                case .currentYearCitations:
+                    if let currentYearCitations = metrics.currentYearCitations {
+                        let formattedCurrentYear = NumberFormatter.localizedString(
+                            from: NSNumber(value: currentYearCitations),
+                            number: .decimal
+                        )
+                        countText = "    \(formattedCurrentYear) citations in \(currentYear)"
+                        countIcon = "calendar"
+                    } else {
+                        countText = "    Current-year citations unavailable"
+                        countIcon = "calendar.badge.exclamationmark"
+                    }
+                    totalSummaryText = "    \(formattedTotal) total citations"
+                }
             }
             
             let countItem = NSMenuItem(title: countText, action: nil, keyEquivalent: "")
@@ -237,6 +255,15 @@ import Cocoa
             countItem.image = NSImage(systemSymbolName: countIcon, accessibilityDescription: "Citations")
             menu.insertItem(countItem, at: insertIndex)
             insertIndex += 1
+
+            if let totalSummaryText {
+                let totalItem = NSMenuItem(title: totalSummaryText, action: nil, keyEquivalent: "")
+                totalItem.tag = 100
+                totalItem.isEnabled = false
+                totalItem.image = NSImage(systemSymbolName: "book.closed", accessibilityDescription: "Total citations")
+                menu.insertItem(totalItem, at: insertIndex)
+                insertIndex += 1
+            }
             
             // Add h-index if available
             if settingsManager.settings.showHIndexInMenu, let hIndex = metrics.hIndex {
@@ -340,13 +367,42 @@ import Cocoa
         updateDisplayWith(currentCitations)
     }
     
-    private func updateMenuBarWithCount(_ count: Int) {
+    private func updateMenuBarWithMetrics(_ metrics: ProfileMetrics) {
         // Display count as text next to icon. If the SF Symbol fails to render,
         // keep the title visible so users still see launch/refresh progress.
-        let title = count > 0 ? " \(count)" : " --"
+        let displayValue: Int
+        let symbolName: String
+        let accessibilityDescription: String
+
+        switch settingsManager.settings.menuBarPrimaryMetric {
+        case .totalCitations:
+            displayValue = metrics.citationCount
+            symbolName = "book.circle.fill"
+            accessibilityDescription = "CiteBar"
+        case .currentYearCitations:
+            if let currentYearCitations = metrics.currentYearCitations {
+                displayValue = currentYearCitations
+                symbolName = "calendar.circle.fill"
+                accessibilityDescription = "CiteBar - Current year citations"
+            } else {
+                // Fall back to the total count when yearly histogram data is unavailable.
+                displayValue = metrics.citationCount
+                symbolName = "book.circle.fill"
+                accessibilityDescription = "CiteBar"
+            }
+        }
+
+        let title: String
+        if displayValue >= 0 {
+            let formattedValue = NumberFormatter.localizedString(from: NSNumber(value: displayValue), number: .decimal)
+            title = " \(formattedValue)"
+        } else {
+            title = " --"
+        }
+
         applyStatusIcon(
-            symbolName: "book.circle.fill",
-            accessibilityDescription: "CiteBar",
+            symbolName: symbolName,
+            accessibilityDescription: accessibilityDescription,
             preferredTitle: title,
             fallbackTitle: title
         )

--- a/Sources/CiteBar/Models.swift
+++ b/Sources/CiteBar/Models.swift
@@ -29,6 +29,14 @@ struct ScholarMetrics {
     let citationCount: Int
     let hIndex: Int?
     let i10Index: Int?
+    let citationsByYear: [Int: Int]?
+
+    init(citationCount: Int, hIndex: Int? = nil, i10Index: Int? = nil, citationsByYear: [Int: Int]? = nil) {
+        self.citationCount = citationCount
+        self.hIndex = hIndex
+        self.i10Index = i10Index
+        self.citationsByYear = citationsByYear
+    }
 }
 
 struct CitationRecord: Codable {
@@ -36,13 +44,15 @@ struct CitationRecord: Codable {
     let citationCount: Int
     let hIndex: Int?
     let i10Index: Int?
+    let citationsByYear: [Int: Int]?
     let timestamp: Date
 
-    init(profileId: String, citationCount: Int, hIndex: Int? = nil, i10Index: Int? = nil, timestamp: Date = Date()) {
+    init(profileId: String, citationCount: Int, hIndex: Int? = nil, i10Index: Int? = nil, citationsByYear: [Int: Int]? = nil, timestamp: Date = Date()) {
         self.profileId = profileId
         self.citationCount = citationCount
         self.hIndex = hIndex
         self.i10Index = i10Index
+        self.citationsByYear = citationsByYear
         self.timestamp = timestamp
     }
 }
@@ -57,6 +67,7 @@ struct AppSettings: Codable {
     var showHIndexInMenu: Bool = true
     var showI10IndexInMenu: Bool = true
     var showTrendInMenu: Bool = true
+    var menuBarPrimaryMetric: MenuBarPrimaryMetric = .totalCitations
 
     enum CodingKeys: String, CodingKey {
         case profiles
@@ -68,6 +79,32 @@ struct AppSettings: Codable {
         case showHIndexInMenu
         case showI10IndexInMenu
         case showTrendInMenu
+        case menuBarPrimaryMetric
+    }
+
+    enum MenuBarPrimaryMetric: String, CaseIterable, Codable {
+        case totalCitations = "totalCitations"
+        case currentYearCitations = "currentYearCitations"
+
+        var displayName: String {
+            switch self {
+            case .totalCitations:
+                return "Total citations"
+            case .currentYearCitations:
+                return "Current year citations"
+            }
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let rawValue = try container.decode(String.self)
+            self = MenuBarPrimaryMetric(rawValue: rawValue) ?? .totalCitations
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(rawValue)
+        }
     }
 
     init() {}
@@ -83,6 +120,7 @@ struct AppSettings: Codable {
         showHIndexInMenu = try container.decodeIfPresent(Bool.self, forKey: .showHIndexInMenu) ?? true
         showI10IndexInMenu = try container.decodeIfPresent(Bool.self, forKey: .showI10IndexInMenu) ?? true
         showTrendInMenu = try container.decodeIfPresent(Bool.self, forKey: .showTrendInMenu) ?? true
+        menuBarPrimaryMetric = try container.decodeIfPresent(MenuBarPrimaryMetric.self, forKey: .menuBarPrimaryMetric) ?? .totalCitations
     }
     
     enum RefreshInterval: String, CaseIterable, Codable {
@@ -138,6 +176,20 @@ struct ProfileMetrics {
     let citationCount: Int
     let hIndex: Int?
     let i10Index: Int?
+    let citationsByYear: [Int: Int]?
+
+    init(citationCount: Int, hIndex: Int? = nil, i10Index: Int? = nil, citationsByYear: [Int: Int]? = nil) {
+        self.citationCount = citationCount
+        self.hIndex = hIndex
+        self.i10Index = i10Index
+        self.citationsByYear = citationsByYear
+    }
+
+    var currentYearCitations: Int? {
+        guard let citationsByYear else { return nil }
+        let currentYear = Calendar.current.component(.year, from: Date())
+        return citationsByYear[currentYear] ?? 0
+    }
 }
 
 @MainActor protocol CitationManagerDelegate: AnyObject {

--- a/Sources/CiteBar/SettingsManager.swift
+++ b/Sources/CiteBar/SettingsManager.swift
@@ -79,6 +79,11 @@ import ServiceManagement
         settings.showTrendInMenu = enabled
         save()
     }
+
+    func setMenuBarPrimaryMetric(_ metric: AppSettings.MenuBarPrimaryMetric) {
+        settings.menuBarPrimaryMetric = metric
+        save()
+    }
     
     func setAutoLaunch(_ enabled: Bool) {
         settings.autoLaunch = enabled

--- a/Sources/CiteBar/SettingsView.swift
+++ b/Sources/CiteBar/SettingsView.swift
@@ -451,6 +451,17 @@ struct GeneralTab: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
+
+                        Divider()
+
+                        SettingsActionRow(
+                            text: "Need immediate data? Trigger a refresh now.",
+                            buttonTitle: "Refresh Now"
+                        ) {
+                            if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+                                appDelegate.refreshCitations()
+                            }
+                        }
                     }
                 }
 
@@ -539,13 +550,34 @@ struct GeneralTab: View {
 
                 SettingsCard(
                     title: "Menu Bar Display",
-                    subtitle: "Citation count is always shown. Toggle optional metrics below."
+                    subtitle: "Choose which citation metric appears in the menu bar, then toggle optional details below."
                 ) {
                     VStack(alignment: .leading, spacing: 10) {
                         Text("To change profile order (and which profile appears first), use the Profiles section and drag rows.")
                             .font(.caption)
                             .foregroundColor(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
+
+                        Divider()
+
+                        SettingsControlRow("Primary citation metric") {
+                            Picker("Primary citation metric", selection: Binding(
+                                get: { settingsManager.settings.menuBarPrimaryMetric },
+                                set: { metric in
+                                    settingsManager.setMenuBarPrimaryMetric(metric)
+                                    if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+                                        appDelegate.updateMenuBarDisplay()
+                                    }
+                                }
+                            )) {
+                                ForEach(AppSettings.MenuBarPrimaryMetric.allCases, id: \.self) { metric in
+                                    Text(metric.displayName).tag(metric)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
+                            .fixedSize(horizontal: true, vertical: false)
+                        }
 
                         Divider()
 
@@ -581,6 +613,20 @@ struct GeneralTab: View {
                                 }
                             )
                         )
+                    }
+                }
+
+                SettingsCard(
+                    title: "App",
+                    subtitle: "Lower-frequency app controls."
+                ) {
+                    SettingsActionRow(
+                        text: "Quit CiteBar and stop background refresh until the app is opened again.",
+                        buttonTitle: "Quit CiteBar"
+                    ) {
+                        if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+                            appDelegate.quitApp()
+                        }
                     }
                 }
             }
@@ -630,6 +676,17 @@ struct AboutTab: View {
                                     .background(Color.accentColor.opacity(0.14))
                                     .clipShape(Capsule())
                             }
+
+                            Button {
+                                if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+                                    appDelegate.checkForUpdates()
+                                }
+                            } label: {
+                                Label("Check for Updates...", systemImage: "arrow.down.circle")
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .padding(.top, 2)
                         }
 
                         Spacer()

--- a/Tests/CiteBarTests/CiteBarTests.swift
+++ b/Tests/CiteBarTests/CiteBarTests.swift
@@ -133,6 +133,7 @@ final class CiteBarTests: XCTestCase {
         XCTAssertTrue(settings.showHIndexInMenu)
         XCTAssertTrue(settings.showI10IndexInMenu)
         XCTAssertTrue(settings.showTrendInMenu)
+        XCTAssertEqual(settings.menuBarPrimaryMetric, .totalCitations)
     }
 
     func testAppSettingsBackwardCompatibilityDecodingDefaultsNewDisplayOptions() throws {
@@ -150,6 +151,7 @@ final class CiteBarTests: XCTestCase {
         XCTAssertTrue(decoded.showHIndexInMenu)
         XCTAssertTrue(decoded.showI10IndexInMenu)
         XCTAssertTrue(decoded.showTrendInMenu)
+        XCTAssertEqual(decoded.menuBarPrimaryMetric, .totalCitations)
     }
 
     // New tests for CitationManager
@@ -174,6 +176,10 @@ final class CiteBarTests: XCTestCase {
         XCTAssertEqual(metrics.citationCount, 98, "Citation count should be parsed correctly from the sample HTML.")
         XCTAssertEqual(metrics.hIndex, 4, "h-index should be parsed correctly from the sample HTML.")
         XCTAssertEqual(metrics.i10Index, 2, "i10-index should be parsed correctly from the sample HTML.")
+        XCTAssertEqual(metrics.citationsByYear?[2022], 3, "2022 yearly citations should be parsed from the citation graph.")
+        XCTAssertEqual(metrics.citationsByYear?[2023], 10, "2023 yearly citations should be parsed from the citation graph.")
+        XCTAssertEqual(metrics.citationsByYear?[2024], 59, "2024 yearly citations should be parsed from the citation graph.")
+        XCTAssertEqual(metrics.citationsByYear?[2025], 25, "2025 yearly citations should be parsed from the citation graph.")
     }
     
     @MainActor


### PR DESCRIPTION
## Summary
This PR implements the request in #19 by adding a user-selectable menu bar metric:
- Total citations (default)
- Current-year citations

It also refines Settings action placement to better match user intent and reduce accidental usage.

## What changed
- Parse Google Scholar "Citations per year" histogram data and carry it through the metrics pipeline.
- Persist per-year citation data in citation history records.
- Add a new setting: `Primary citation metric` in General → Menu Bar Display.
- Update menu bar and dropdown rendering to support current-year mode.
- Add graceful fallback to total citations when yearly histogram data is unavailable.
- Move `Refresh Now` into the `Refresh Schedule` card.
- Move `Check for Updates...` next to version info in `About`.
- Move `Quit CiteBar` to a low-priority `App` card at the bottom of `General`.
- Add tests for:
  - settings default/legacy decoding behavior
  - yearly histogram parsing from sample Scholar HTML

## Backward compatibility
- Existing users keep the current behavior by default (`Total citations`).
- Unknown or legacy metric values decode safely to `Total citations`.

## Validation
- `swift test` passes (14/14).

## Issue
Closes #19
