### PR TITLE
release(distribution): prepare notarized 1.5.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
         description: 'Version to release (e.g., 1.3.1)'
         required: true
         type: string
+      dry_run:
+        description: 'Build, sign, notarize, and upload artifacts without publishing a GitHub Release'
+        required: false
+        default: true
+        type: boolean
 
 # Grant GITHUB_TOKEN the permissions required to make releases
 permissions:
@@ -66,6 +71,54 @@ jobs:
         fi
         
         echo "SPARKLE_PUBLIC_ED_KEY=$PUBLIC_ED_KEY" >> $GITHUB_ENV
+
+    - name: Validate Apple signing configuration
+      env:
+        DEVELOPER_ID_APPLICATION: ${{ secrets.DEVELOPER_ID_APPLICATION }}
+        MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+        MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+      run: |
+        missing=0
+        for name in DEVELOPER_ID_APPLICATION MACOS_CERTIFICATE_P12 MACOS_CERTIFICATE_PASSWORD APPLE_ID APPLE_TEAM_ID APP_SPECIFIC_PASSWORD; do
+          if [ -z "${!name}" ]; then
+            echo "Error: Missing GitHub secret: $name"
+            missing=1
+          fi
+        done
+
+        if [ "$missing" -ne 0 ]; then
+          exit 1
+        fi
+
+    - name: Import Developer ID certificate
+      env:
+        DEVELOPER_ID_APPLICATION: ${{ secrets.DEVELOPER_ID_APPLICATION }}
+        MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+        MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      run: |
+        CERTIFICATE_PATH="$RUNNER_TEMP/developer_id_application.p12"
+        KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+        KEYCHAIN_PASSWORD="${KEYCHAIN_PASSWORD:-temporary-password-${{ github.run_id }}}"
+
+        echo "$MACOS_CERTIFICATE_P12" | base64 --decode > "$CERTIFICATE_PATH"
+
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | sed 's/"//g')
+        security default-keychain -s "$KEYCHAIN_PATH"
+        security import "$CERTIFICATE_PATH" -k "$KEYCHAIN_PATH" -P "$MACOS_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+        if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -F "$DEVELOPER_ID_APPLICATION"; then
+          echo "Error: Developer ID identity not found in keychain: $DEVELOPER_ID_APPLICATION"
+          exit 1
+        fi
         
     - name: Update version in code
       run: |
@@ -111,6 +164,7 @@ jobs:
         make package
       env:
         SPARKLE_PUBLIC_ED_KEY: ${{ env.SPARKLE_PUBLIC_ED_KEY }}
+        SIGN_IDENTITY: ${{ secrets.DEVELOPER_ID_APPLICATION }}
         
     - name: Create DMG
       run: |
@@ -138,6 +192,53 @@ jobs:
           ls -la dist/
           exit 1
         fi
+      env:
+        SPARKLE_PUBLIC_ED_KEY: ${{ env.SPARKLE_PUBLIC_ED_KEY }}
+        SIGN_IDENTITY: ${{ secrets.DEVELOPER_ID_APPLICATION }}
+
+    - name: Capture signing diagnostics
+      run: |
+        set -o pipefail
+        mkdir -p dist/notary-logs
+        {
+          echo "DMG:"
+          ls -lh "dist/${{ steps.dmg_name.outputs.DMG_NAME }}.dmg"
+          codesign --verify --verbose=4 "dist/${{ steps.dmg_name.outputs.DMG_NAME }}.dmg"
+          codesign -dv --verbose=4 "dist/${{ steps.dmg_name.outputs.DMG_NAME }}.dmg"
+          echo
+          echo "App bundle verification:"
+          codesign --verify --strict --deep --verbose=4 dist/CiteBar.app
+          echo
+          echo "Main executable verification:"
+          codesign --verify --strict --verbose=4 dist/CiteBar.app/Contents/MacOS/CiteBar
+          codesign -dv --verbose=4 dist/CiteBar.app/Contents/MacOS/CiteBar
+          echo
+          echo "Sparkle framework binary verification:"
+          codesign --verify --strict --verbose=4 dist/CiteBar.app/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle
+          codesign -dv --verbose=4 dist/CiteBar.app/Contents/Frameworks/Sparkle.framework/Versions/B/Sparkle
+          echo
+          echo "Gatekeeper pre-notarization assessment:"
+          spctl -a -vvv -t exec dist/CiteBar.app || true
+        } 2>&1 | tee dist/notary-logs/signing-diagnostics.txt
+
+    - name: Notarize and staple DMG
+      env:
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+        NOTARY_TIMEOUT_SECONDS: 3600
+      run: |
+        scripts/notarize-dmg.sh "dist/${{ steps.dmg_name.outputs.DMG_NAME }}.dmg"
+
+    - name: Upload notarization diagnostics
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: notarization-diagnostics-${{ steps.get_version.outputs.TAG }}
+        path: |
+          dist/notary-logs/**
+        if-no-files-found: warn
+        retention-days: 14
 
     - name: Build Sparkle sign_update tool
       run: |
@@ -211,8 +312,22 @@ jobs:
         # Generate release notes from AppVersion.swift
         RELEASE_NOTES_MARKDOWN=$(swift scripts/extract-release-notes.swift markdown)
         echo "$RELEASE_NOTES_MARKDOWN" > release-notes.md
+
+    - name: Upload dry-run release artifacts
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: citebar-${{ steps.dmg_name.outputs.VERSION_FROM_FILE }}-dry-run-release
+        path: |
+          dist/${{ steps.dmg_name.outputs.DMG_NAME }}.dmg
+          appcast.xml
+          release-notes.md
+          dist/notary-logs/**
+        if-no-files-found: error
+        retention-days: 14
         
     - name: Publish Release
+      if: ${{ github.event_name == 'push' || inputs.dry_run == false }}
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ steps.get_version.outputs.TAG }}

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ Temporary Items
 
 # Logs
 *.log
+notary-log*.json
 
 # Sparkle signing keys
 .sparkle/private_ed_key.txt

--- a/APPLE_DISTRIBUTION.md
+++ b/APPLE_DISTRIBUTION.md
@@ -1,0 +1,224 @@
+# Apple Developer ID Distribution Setup
+
+This project distributes CiteBar outside the Mac App Store. The production release path is:
+
+1. Build a universal macOS app bundle.
+2. Sign the app and embedded Sparkle framework with a `Developer ID Application` certificate.
+3. Create the drag-to-Applications DMG.
+4. Sign the DMG container with the same `Developer ID Application` certificate.
+5. Submit the DMG to Apple's notary service with `notarytool`.
+6. Staple the notarization ticket to the DMG.
+7. Publish the notarized DMG and Sparkle appcast on GitHub Releases.
+
+Apple references:
+
+- [Signing Mac Software with Developer ID](https://developer.apple.com/developer-id/)
+- [Notarizing macOS software before distribution](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)
+- [Customizing the notarization workflow](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow)
+- [TN3147: Migrating to the latest notarization tool](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool)
+
+## What You Need From Apple
+
+You need these values and credentials. Do not commit private keys, `.p12` files, or app-specific passwords.
+
+| Name | Where to get it | Used as |
+| --- | --- | --- |
+| Apple ID email | Apple Developer account login | `APPLE_ID` |
+| Team ID | Apple Developer account membership page | `APPLE_TEAM_ID` |
+| Developer ID Application identity | Keychain Access after importing the certificate | `DEVELOPER_ID_APPLICATION` |
+| Developer ID Application `.p12` | Export from Keychain Access | `MACOS_CERTIFICATE_P12` |
+| `.p12` export password | You choose this during export | `MACOS_CERTIFICATE_PASSWORD` |
+| App-specific password | appleid.apple.com account security settings | `APP_SPECIFIC_PASSWORD` |
+| Sparkle public/private EdDSA keys | Existing `RELEASING.md` Sparkle setup | `SPARKLE_PUBLIC_ED_KEY`, `SPARKLE_PRIVATE_KEY` |
+
+The signing identity must look like:
+
+```text
+Developer ID Application: Your Legal Name or Company Name (TEAMID1234)
+```
+
+## Apple Developer Portal Setup
+
+1. Sign in to <https://developer.apple.com/account/>.
+2. Confirm the membership is active and you can access Certificates, Identifiers & Profiles.
+3. Create or download a `Developer ID Application` certificate:
+   - Open Certificates, Identifiers & Profiles.
+   - Add a certificate.
+   - Choose `Developer ID Application`.
+   - If Apple asks for a CSR, create one in Keychain Access using Certificate Assistant.
+   - Download the generated `.cer` file.
+   - Double-click it so it imports into your login keychain.
+4. In Keychain Access, find the certificate and verify it has a private key under it.
+5. Export it as a `.p12`:
+   - Select the certificate and private key.
+   - File > Export Items.
+   - Format: Personal Information Exchange (`.p12`).
+   - Set a strong export password and save it somewhere secure.
+6. Create an app-specific password:
+   - Go to <https://appleid.apple.com/>.
+   - Sign-In and Security > App-Specific Passwords.
+   - Generate one named `CiteBar Notarization`.
+
+## Local Machine Setup
+
+Install or update Xcode from the Mac App Store, then make sure command line tools use that Xcode:
+
+```bash
+xcode-select -p
+xcodebuild -version
+xcrun notarytool --help
+```
+
+Store notarization credentials in your local keychain:
+
+```bash
+xcrun notarytool store-credentials "CiteBar Notary" \
+  --apple-id "you@example.com" \
+  --team-id "TEAMID1234"
+```
+
+When prompted, paste the app-specific password.
+
+Find the exact signing identity:
+
+```bash
+security find-identity -v -p codesigning | grep "Developer ID Application"
+```
+
+Build, sign, notarize, and staple locally:
+
+```bash
+make notarize \
+  SIGN_IDENTITY="Developer ID Application: Your Legal Name (TEAMID1234)" \
+  NOTARY_PROFILE="CiteBar Notary"
+```
+
+The final DMG will be in `dist/`.
+
+## GitHub Secrets Setup
+
+Base64-encode the `.p12` for GitHub Actions:
+
+```bash
+base64 -i DeveloperIDApplication.p12 -o DeveloperIDApplication.p12.base64
+```
+
+Configure these GitHub repository secrets:
+
+```bash
+gh secret set DEVELOPER_ID_APPLICATION --body "Developer ID Application: Your Legal Name (TEAMID1234)"
+gh secret set MACOS_CERTIFICATE_P12 < DeveloperIDApplication.p12.base64
+gh secret set MACOS_CERTIFICATE_PASSWORD --body "your-p12-export-password"
+gh secret set APPLE_ID --body "you@example.com"
+gh secret set APPLE_TEAM_ID --body "TEAMID1234"
+gh secret set APP_SPECIFIC_PASSWORD --body "xxxx-xxxx-xxxx-xxxx"
+```
+
+Optional, only if you want to control the temporary CI keychain password:
+
+```bash
+gh secret set KEYCHAIN_PASSWORD --body "a-long-random-temporary-keychain-password"
+```
+
+Sparkle secrets are still required:
+
+```bash
+gh variable set SPARKLE_PUBLIC_ED_KEY --body "your-public-ed-key"
+gh secret set SPARKLE_PRIVATE_KEY < .sparkle/private_ed_key.txt
+```
+
+## Release
+
+After the secrets are configured, the existing release workflow will sign, notarize, staple, generate the Sparkle appcast, and publish the release when a version tag is pushed:
+
+```bash
+git tag v1.x.y
+git push origin v1.x.y
+```
+
+You can also start the workflow manually from GitHub Actions and provide the version.
+
+## Verification
+
+For a local DMG:
+
+```bash
+codesign --verify --verbose=4 dist/CiteBar-*.dmg
+xcrun stapler validate dist/CiteBar-*.dmg
+spctl -a -vvv -t open --context context:primary-signature dist/CiteBar-*.dmg
+```
+
+For the app bundle before DMG creation:
+
+```bash
+codesign --verify --strict --deep --verbose=2 dist/CiteBar.app
+codesign -dv --verbose=4 dist/CiteBar.app
+spctl -a -vvv -t exec dist/CiteBar.app
+```
+
+Expected outcome:
+
+- `codesign` verification succeeds.
+- `spctl` shows accepted Developer ID assessment for the signed DMG.
+- `stapler validate` confirms the ticket is attached.
+- A fresh Mac can open the downloaded DMG, drag CiteBar to Applications, and launch without Terminal commands.
+
+## Notarization Diagnostics
+
+The notarization script writes diagnostics for every submission under:
+
+```bash
+dist/notary-logs/
+```
+
+Each run gets its own timestamped directory and `dist/notary-logs/latest` points to the newest run. Important files:
+
+- `submit.json`: the upload response with the Apple submission ID.
+- `submission-id.txt`: the Apple submission ID only.
+- `poll-001.json`, `poll-002.json`, etc.: every status response from `notarytool info`.
+- `latest-info.json`: the newest status response.
+- `submission-log.json`: the Apple notary submission log, when Apple makes it available.
+- `signing-diagnostics.txt`: GitHub Actions signing checks before notarization.
+
+If notarization is slow, check the current status:
+
+```bash
+SUBMISSION_ID=$(cat dist/notary-logs/latest/submission-id.txt)
+xcrun notarytool info "$SUBMISSION_ID" --keychain-profile "CiteBar Notary"
+```
+
+If notarization fails or remains stuck long enough to contact Apple Developer Support, collect:
+
+```bash
+SUBMISSION_ID=$(cat dist/notary-logs/latest/submission-id.txt)
+xcrun notarytool log "$SUBMISSION_ID" --keychain-profile "CiteBar Notary" \
+  "dist/notary-logs/latest/submission-log.json"
+```
+
+When contacting Apple Developer Support, include:
+
+- Team ID.
+- Submission ID.
+- DMG filename.
+- `latest-info.json`.
+- `submission-log.json`, if available.
+- A short note that this is a Developer ID notarization submission using `notarytool`.
+
+Apple's Notary API also exposes a submission-log endpoint; `xcrun notarytool log` is the local CLI wrapper around the same diagnostic information.
+
+In GitHub Actions, the release workflow uploads `notarization-diagnostics-*` as an artifact even if the notarization step fails or times out. Download that artifact from the failed workflow run before rerunning the release.
+
+## Information To Provide To A Maintainer
+
+Provide only these non-secret values in chat:
+
+- `APPLE_TEAM_ID`
+- Exact `DEVELOPER_ID_APPLICATION` string
+- Whether you want releases built locally or by GitHub Actions
+
+Provide these only through GitHub Secrets or another secure channel:
+
+- `MACOS_CERTIFICATE_P12`
+- `MACOS_CERTIFICATE_PASSWORD`
+- `APP_SPECIFIC_PASSWORD`
+- `SPARKLE_PRIVATE_KEY`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to CiteBar will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-04-27
+
+### Added
+- **Apple Developer ID Distribution**: Public releases are now signed with Apple Developer ID and notarized by Apple so macOS can verify CiteBar on first launch
+- **Signed DMG Release Path**: Release packaging now signs the app bundle, main executable, Sparkle framework binary, nested Sparkle helpers, and DMG container before notarization
+- **Notarization Diagnostics**: Local and GitHub Actions release flows now capture submission IDs, polling results, Apple notary logs, signing diagnostics, and uploaded CI artifacts for troubleshooting
+- **Permission Recovery Guidance**: Settings now provide guided recovery actions for launch-at-login and notification permissions
+- **Menu Bar Compatibility Guidance**: Settings now explain menu bar manager delays and offer clearer recovery paths when macOS delays status item creation
+
+### Changed
+- **Distribution UX**: The standard release artifact is now a notarized drag-to-Applications DMG intended to install without Terminal commands or manual Gatekeeper workarounds
+- **Release Documentation**: Added Apple Developer setup, local release verification, GitHub Secrets setup, and support escalation guidance for notarization issues
+- **Website Messaging**: Refined landing page messaging and feature layout to focus on the product workflow and simpler install story
+
+### Fixed
+- **Settings Window Positioning**: Settings now stays centered when opened or reopened from the menu bar
+- **Status Item Robustness**: Menu bar startup handling now recovers more gracefully when status item creation is delayed
+
+### Technical
+- Added `CiteBar.entitlements`, `scripts/sign-app.sh`, and `scripts/notarize-dmg.sh`
+- Added `NSAppleEventsUsageDescription` for the optional AppleScript launch-at-login fallback
+- Updated GitHub Actions release workflow to import Developer ID certificates, validate signatures, notarize, staple, and upload diagnostics
+- Updated DMG packaging to start from clean staging directories, copy bundles with `ditto`, sign the DMG container, and verify signing before notarization
+- Added documentation consistency checks and a Makefile `xcode` helper target
+
 ## [1.4.9] - 2026-03-10
 
 ### Added
@@ -426,11 +451,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [ ] Push notifications for citation updates
 - [ ] Advanced profile management (bulk import, profile templates)
 
-### [1.5.0] - Planned
-- [ ] Apple App Store distribution
+### [1.6.0] - Planned
 - [ ] Performance optimizations
 - [ ] Additional citation metrics
 - [ ] Enhanced notification settings
+- [ ] Mac App Store distribution exploration
 
 ### [2.0.0] - Future
 - [ ] Integration with other academic platforms

--- a/CiteBar.entitlements
+++ b/CiteBar.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -1,75 +1,44 @@
-# CiteBar Distribution Guide
+# CiteBar Install Guide
 
 ## Download and Installation
 
-### DMG Installation (Only Distribution Method)
-1. Download the latest `CiteBar-x.x.x-universal-[date].dmg` file from [Releases](https://github.com/hichipli/CiteBar/releases)
-2. Double-click the DMG file to open it
-3. Drag `CiteBar.app` to the `Applications` folder
-4. Find CiteBar in Applications and run it
+### Standard Install
+1. Download the latest `CiteBar-x.x.x-universal-[date].dmg` file from [Releases](https://github.com/hichipli/CiteBar/releases/latest).
+2. Double-click the DMG file to open it.
+3. Drag `CiteBar.app` to the `Applications` folder.
+4. Open CiteBar from Applications.
 
-**Note**: CiteBar is only distributed as DMG files. No standalone .app files are provided in releases.  
-The `universal` DMG supports both Apple Silicon and Intel Macs, so there is no separate chip-specific download.
+The `universal` DMG works on both Apple Silicon and Intel Macs, so there is no chip-specific download.
 
 ## Troubleshooting Common Issues
 
-### Issue 1: "CiteBar is damaged and can't be opened"
-This is macOS security mechanism because the app doesn't have an Apple Developer Certificate signature. Solutions:
+### "CiteBar is damaged and can't be opened"
+Version `1.5.0` and later are signed with Apple Developer ID and notarized by Apple. If you see this message on a current release, delete the downloaded DMG and download the latest release again from the official GitHub Releases page.
 
-**Method A: Remove quarantine attribute (Recommended)**
-```bash
-xattr -cr /Applications/CiteBar.app
-```
+Older releases before `1.5.0` were not notarized and may show this warning on newer macOS versions. The recommended fix is to install the latest release.
 
-**Method B: Allow through System Preferences**
-1. Try to run the app, it will show a security warning
-2. Open `System Preferences` > `Privacy & Security` > `Security`
-3. You'll see a message about CiteBar being blocked
-4. Click "Open Anyway" button next to the message
+### "Cannot verify developer"
+Current releases should show a verified Developer ID prompt on first launch. If macOS cannot verify the developer, confirm you downloaded the latest DMG from the official GitHub Releases page and are installing version `1.5.0` or later.
 
-### Issue 2: "Cannot verify developer"
-1. Right-click on `CiteBar.app`
-2. Select "Open"
-3. Click "Open" in the popup dialog
+### Application won't start
+Delete `/Applications/CiteBar.app`, download the latest DMG again, and drag the app to Applications once more. If the problem persists, open an issue with your macOS version and a screenshot of the error.
 
-### Issue 3: Application won't start
-If the above methods don't work, try:
-```bash
-# Remove all extended attributes
-sudo xattr -cr /Applications/CiteBar.app
-
-# Reapply permissions
-sudo chmod -R 755 /Applications/CiteBar.app
-```
-
-### Issue 4: Older versions fail during in-app update
+### Older versions fail during in-app update
 If you are on `1.3.x` or `1.4.1`, automatic install may fail during signature validation.  
-Please manually install the latest DMG from [Releases](https://github.com/hichipli/CiteBar/releases/latest) once, then automatic updates should work normally on `1.4.4+`.
+Please manually install the latest DMG from [Releases](https://github.com/hichipli/CiteBar/releases/latest) once, then automatic updates should work normally on newer versions.
 
-If macOS blocks launch after manual install, run:
-```bash
-xattr -cr /Applications/CiteBar.app
-```
+If macOS blocks a pre-`1.5.0` build, upgrade to the latest release rather than keeping the older build.
 
 ## Security Information
 
-- This application uses **ad-hoc signing** (self-signing), which is standard practice for temporary distribution
-- Automatic in-app updates are validated with **Sparkle EdDSA signatures** (`SUPublicEDKey` + `sparkle:edSignature`)
-- The application is open source, you can review the source code for security verification
-- Future versions will use Apple Developer Certificate for official signing
-
-## Technical Details
-
-macOS from Catalina (10.15) onwards has stricter security checks for network-downloaded applications:
-- Locally built applications can run normally
-- Network-downloaded applications get "quarantine" attributes
-- Apps without Apple notarization are marked as "damaged"
-
-This is not actual damage, but a security mechanism. The above methods allow safe execution of the application.
+- Current public releases use Apple Developer ID signing and Apple notarization for distribution outside the Mac App Store.
+- Automatic in-app updates are validated with Sparkle update signatures.
+- CiteBar is open source, so you can review the source code at any time.
 
 ## Support
 
 If you still have issues, please submit an Issue on the GitHub repository including:
 - macOS version
+- CiteBar version
 - Error message screenshots
-- Solutions you've tried 
+- Solutions you've tried

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
-.PHONY: build debug run run-debug test clean install install-sudo package dmg xcode check-docs help
+.PHONY: build debug run run-debug test clean install install-sudo package dmg notarize xcode check-docs help
 
 # Configuration variables - easy to change for different projects
 PRODUCT_NAME = CiteBar
 SCHEME = CiteBar
 BUILD_DIR = .build
+SIGN_IDENTITY ?= -
+ENTITLEMENTS_FILE ?= CiteBar.entitlements
+NOTARY_PROFILE ?=
+APPLE_ID ?=
+APPLE_TEAM_ID ?=
+APP_SPECIFIC_PASSWORD ?=
 
 # Extract version from AppVersion.swift (primary source)
 VERSION = $(shell grep 'static let current' Sources/CiteBar/AppVersion.swift | cut -d'"' -f2)
@@ -78,12 +84,8 @@ install: build
 	@if [ -d "$(PRODUCT_NAME).app/Contents/Frameworks/Sparkle.framework" ]; then \
 		echo "🔧 Fixing rpath for Sparkle framework..."; \
 		install_name_tool -add_rpath @loader_path/../Frameworks "$(PRODUCT_NAME).app/Contents/MacOS/$(PRODUCT_NAME)" 2>/dev/null || true; \
-		echo "🔏 Re-signing Sparkle framework..."; \
-		codesign --force --deep --sign - "$(PRODUCT_NAME).app/Contents/Frameworks/Sparkle.framework" 2>/dev/null || true; \
 	fi
-	# Apply ad-hoc code signing
-	@echo "🔐 Applying ad-hoc code signature..."
-	@codesign --force --deep --sign - "$(PRODUCT_NAME).app" || echo "⚠️  Warning: Code signing failed"
+	@SIGN_IDENTITY="$(SIGN_IDENTITY)" ENTITLEMENTS_FILE="$(ENTITLEMENTS_FILE)" ./scripts/sign-app.sh "$(PRODUCT_NAME).app" "$(PRODUCT_NAME)"
 	@echo "App bundle created: $(PRODUCT_NAME).app"
 	@echo ""
 	@echo "To complete installation:"
@@ -112,12 +114,8 @@ install-sudo: build
 	@if [ -d "$(PRODUCT_NAME).app/Contents/Frameworks/Sparkle.framework" ]; then \
 		echo "🔧 Fixing rpath for Sparkle framework..."; \
 		install_name_tool -add_rpath @loader_path/../Frameworks "$(PRODUCT_NAME).app/Contents/MacOS/$(PRODUCT_NAME)" 2>/dev/null || true; \
-		echo "🔏 Re-signing Sparkle framework..."; \
-		codesign --force --deep --sign - "$(PRODUCT_NAME).app/Contents/Frameworks/Sparkle.framework" 2>/dev/null || true; \
 	fi
-	# Apply ad-hoc code signing before installation
-	@echo "🔐 Applying ad-hoc code signature..."
-	@codesign --force --deep --sign - "$(PRODUCT_NAME).app" || echo "⚠️  Warning: Code signing failed"
+	@SIGN_IDENTITY="$(SIGN_IDENTITY)" ENTITLEMENTS_FILE="$(ENTITLEMENTS_FILE)" ./scripts/sign-app.sh "$(PRODUCT_NAME).app" "$(PRODUCT_NAME)"
 	sudo cp -r "$(PRODUCT_NAME).app" /Applications/
 	# Force macOS to refresh icon cache
 	sudo touch "/Applications/$(PRODUCT_NAME).app"
@@ -125,6 +123,7 @@ install-sudo: build
 
 package: build
 	@echo "Creating installer package in '$(DIST_DIR)/'..."
+	@rm -rf "$(APP_BUNDLE)"
 	@mkdir -p "$(DIST_DIR)"
 	@mkdir -p "$(APP_BUNDLE)/Contents/MacOS"
 	@mkdir -p "$(APP_BUNDLE)/Contents/Resources"
@@ -133,7 +132,7 @@ package: build
 	@# Copy Sparkle framework if it exists
 	@if [ -d "$(RELEASE_SPARKLE_FRAMEWORK)" ]; then \
 		mkdir -p "$(APP_BUNDLE)/Contents/Frameworks"; \
-		cp -R "$(RELEASE_SPARKLE_FRAMEWORK)" "$(APP_BUNDLE)/Contents/Frameworks/"; \
+		ditto "$(RELEASE_SPARKLE_FRAMEWORK)" "$(APP_BUNDLE)/Contents/Frameworks/Sparkle.framework"; \
 		echo "✅ Copied Sparkle framework"; \
 	else \
 		echo "⚠️  Warning: Sparkle framework not found"; \
@@ -155,20 +154,17 @@ package: build
 	@if [ -d "$(APP_BUNDLE)/Contents/Frameworks/Sparkle.framework" ]; then \
 		echo "🔧 Fixing rpath for Sparkle framework..."; \
 		install_name_tool -add_rpath @loader_path/../Frameworks "$(APP_BUNDLE)/Contents/MacOS/$(PRODUCT_NAME)" 2>/dev/null || true; \
-		echo "🔏 Re-signing Sparkle framework..."; \
-		codesign --force --deep --sign - "$(APP_BUNDLE)/Contents/Frameworks/Sparkle.framework" 2>/dev/null || true; \
 	fi
-	@# Apply ad-hoc code signing to prevent "damaged" error on other machines
-	@echo "🔐 Applying ad-hoc code signature..."
-	@codesign --force --deep --sign - "$(APP_BUNDLE)" || { echo "⚠️  Warning: Code signing failed, app may show as damaged on other machines"; }
+	@SIGN_IDENTITY="$(SIGN_IDENTITY)" ENTITLEMENTS_FILE="$(ENTITLEMENTS_FILE)" ./scripts/sign-app.sh "$(APP_BUNDLE)" "$(PRODUCT_NAME)" || { echo "⚠️  Warning: Code signing failed, app may show as damaged on other machines"; exit 1; }
 	@echo "✅ Package created: $(APP_BUNDLE)"
 
 dmg: package
 	@echo "Creating DMG distribution package..."
 	@# Create a temporary directory for DMG contents
+	@rm -rf "$(DMG_TEMP_DIR)"
 	@mkdir -p "$(DMG_TEMP_DIR)"
 	@# Copy the app to the temp directory
-	@cp -r "$(APP_BUNDLE)" "$(DMG_TEMP_DIR)/" || { echo "❌ Failed to copy app bundle"; exit 1; }
+	@ditto "$(APP_BUNDLE)" "$(DMG_TEMP_DIR)/$(PRODUCT_NAME).app" || { echo "❌ Failed to copy app bundle"; exit 1; }
 	@# Create Applications symlink for easy installation
 	@ln -sf /Applications "$(DMG_TEMP_DIR)/Applications"
 	@# Create the DMG
@@ -177,6 +173,11 @@ dmg: package
 		-srcfolder "$(DMG_TEMP_DIR)" \
 		-ov -format UDZO \
 		"$(DIST_DIR)/$(DMG_NAME).dmg" || { echo "❌ Failed to create DMG"; rm -rf "$(DMG_TEMP_DIR)"; exit 1; }
+	@if [ "$(SIGN_IDENTITY)" != "-" ]; then \
+		echo "🔐 Signing DMG with Developer ID..."; \
+		codesign --force --timestamp --sign "$(SIGN_IDENTITY)" "$(DIST_DIR)/$(DMG_NAME).dmg"; \
+		codesign --verify --verbose=4 "$(DIST_DIR)/$(DMG_NAME).dmg"; \
+	fi
 	@# Clean up temp directory
 	@rm -rf "$(DMG_TEMP_DIR)"
 	@echo ""
@@ -190,6 +191,10 @@ dmg: package
 	@echo "  1. Double-clicking the DMG file"
 	@echo "  2. Dragging $(PRODUCT_NAME).app to the Applications folder"
 	@echo ""
+
+notarize: dmg
+	@DMG_FILE="$$(ls -t "$(DIST_DIR)"/$(PRODUCT_NAME)-$(VERSION)-$(ARCH_NAME)-*.dmg | head -1)"; \
+	NOTARY_PROFILE="$(NOTARY_PROFILE)" APPLE_ID="$(APPLE_ID)" APPLE_TEAM_ID="$(APPLE_TEAM_ID)" APP_SPECIFIC_PASSWORD="$(APP_SPECIFIC_PASSWORD)" ./scripts/notarize-dmg.sh "$$DMG_FILE"
 
 xcode:
 	@echo "Opening $(PRODUCT_NAME) in Xcode..."
@@ -212,6 +217,7 @@ help:
 	@echo "  install-sudo - Create app bundle and install to /Applications with sudo"
 	@echo "  package      - Create distribution package in '$(DIST_DIR)/' folder (with ad-hoc signing)"
 	@echo "  dmg          - Create DMG distribution file (includes package step)"
+	@echo "  notarize     - Create DMG, submit it to Apple notary service, and staple ticket"
 	@echo "  xcode        - Open the Swift package in Xcode"
 	@echo "  check-docs   - Verify documented make targets match this Makefile"
 	@echo "  help         - Show this help message"
@@ -223,6 +229,5 @@ help:
 	@echo "  DMG_NAME:     $(DMG_NAME)"
 	@echo ""
 	@echo "Code Signing:"
-	@echo "  All build targets now include ad-hoc signing to prevent 'damaged' errors"
-	@echo "  when distributing via GitHub or other networks. See DISTRIBUTION.md for"
-	@echo "  user installation instructions and troubleshooting."
+	@echo "  SIGN_IDENTITY defaults to '-' for ad-hoc local builds."
+	@echo "  Use SIGN_IDENTITY='Developer ID Application: ... (TEAMID)' for public releases."

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   
   **Track Your Academic Impact in Real-Time**
   
-  A elegant macOS menu bar application that keeps your Google Scholar citation metrics at your fingertips.
+  An elegant macOS menu bar application that keeps your Google Scholar citation metrics at your fingertips.
 
   [![Latest Release](https://img.shields.io/github/v/release/hichipli/CiteBar?style=flat-square)](https://github.com/hichipli/CiteBar/releases)
   [![macOS](https://img.shields.io/badge/macOS-13.0+-blue?style=flat-square)](https://www.apple.com/macos/)
@@ -19,7 +19,7 @@
 
 ## Why CiteBar?
 
-Because refreshing your Google Scholar profile every 20 minutes isn't productive research. CiteBar transforms citation tracking from an obsessive browser tab into a elegant, unobtrusive companion that respects both your attention and Google's servers.
+Because refreshing your Google Scholar profile every 20 minutes isn't productive research. CiteBar transforms citation tracking from an obsessive browser tab into an elegant, unobtrusive companion that respects both your attention and Google's servers.
 
 **Perfect for:** Researchers tracking paper impact, department heads monitoring team metrics, PhD students celebrating their first citations, and anyone who's ever wondered "Did my h-index just go up?"
 
@@ -35,26 +35,13 @@ Because refreshing your Google Scholar profile every 20 minutes isn't productive
    - Double-click the DMG file when downloaded
    - Drag CiteBar.app to the Applications folder
 
-2. **Handle macOS security** (because we're not paying Apple $99/year... yet):
-   
-   **Method 1 - Using Terminal (Quickest):**
-   - Press `Cmd + Space` to open Spotlight search
-   - Type "Terminal" and press Enter
-   - Copy and paste this command, then press Enter:
-   ```bash
-   xattr -cr /Applications/CiteBar.app
-   ```
-   
-   **Method 2 - Through System Settings (No Terminal Required):**
-   - Try to run CiteBar from Applications - it will show a security warning
-   - Go to **System Settings** (or **System Preferences** on older macOS)
-   - Click **Privacy & Security** 
-   - Scroll down to the **Security** section
-   - You'll see a message about CiteBar being blocked
-   - Click **"Open Anyway"** button next to the message
+2. **Open CiteBar**:
+   - Current releases are signed with Apple Developer ID and notarized by Apple
+   - Open CiteBar from Applications
+   - macOS may show a normal first-launch confirmation for downloaded apps
 
 > **Legacy Upgrade Note:** If you're on `1.3.x` or `1.4.1`, you may need one manual upgrade first.  
-> Install the latest DMG from [Releases](https://github.com/hichipli/CiteBar/releases/latest), and after you're on `1.4.4+`, in-app automatic updates should work normally.
+> Install the latest DMG from [Releases](https://github.com/hichipli/CiteBar/releases/latest), and after you're on a current version, in-app automatic updates should work normally.
 
 3. **Set up your profile**:
    - Click the CiteBar icon in menu bar
@@ -238,9 +225,9 @@ CiteBar uses GitHub Actions for automated releases:
    - Repository variable or secret: `SPARKLE_PUBLIC_ED_KEY`
    - Repository secret: `SPARKLE_PRIVATE_KEY`
 2. Tag a version: `git tag v1.x.x && git push --tags`
-3. GitHub Actions builds DMG with version + architecture
-4. Workflow signs the DMG with EdDSA and generates `appcast.xml`
-5. Users get automatic update notifications
+3. GitHub Actions builds the universal DMG
+4. Workflow signs the app and DMG with Developer ID, notarizes with Apple, staples the ticket, and generates `appcast.xml`
+5. Users get a standard drag-to-Applications installer and automatic update notifications
 
 Maintainers: see [RELEASING.md](RELEASING.md) for full release + signing workflow.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,19 @@
 
 This document is for maintainers publishing a new release.
 
+## One-Time Apple Developer ID Setup
+
+CiteBar release DMGs are signed with Developer ID and notarized by Apple. Complete `APPLE_DISTRIBUTION.md` before publishing a public release.
+
+Required GitHub secrets:
+
+- `DEVELOPER_ID_APPLICATION`
+- `MACOS_CERTIFICATE_P12`
+- `MACOS_CERTIFICATE_PASSWORD`
+- `APPLE_ID`
+- `APPLE_TEAM_ID`
+- `APP_SPECIFIC_PASSWORD`
+
 ## One-Time Sparkle Signing Setup
 
 To make automatic updates pass signature validation:
@@ -86,4 +99,12 @@ git push origin v1.x.y
 gh run list --workflow Release --limit 3
 curl -fsSL https://github.com/hichipli/CiteBar/releases/latest/download/appcast.xml \
   | grep -E "sparkle:edSignature|sparkle:shortVersionString|sparkle:version"
+```
+
+For local release candidate verification:
+
+```bash
+make notarize \
+  SIGN_IDENTITY="Developer ID Application: Your Legal Name (TEAMID1234)" \
+  NOTARY_PROFILE="CiteBar Notary"
 ```

--- a/Sources/CiteBar/AppVersion.swift
+++ b/Sources/CiteBar/AppVersion.swift
@@ -3,10 +3,10 @@ import Foundation
 /// Centralized version management for CiteBar
 struct AppVersion {
     /// Current application version
-    static let current: String = "1.4.9"
+    static let current: String = "1.5.0"
     
     /// Current build number
-    static let build: String = "17"
+    static let build: String = "18"
     
     /// Version display string for UI
     static let displayString: String = "Version \(current)"
@@ -38,18 +38,18 @@ extension AppVersion {
     static let releaseNotes = ReleaseNotes(
         version: current,
         highlights: [
-            "Reduced redundant Scholar fetches with one-shot profile snapshot prefetch during onboarding",
-            "Startup refresh now runs only when local data is missing or stale relative to your configured interval",
-            "New profile flow now supports optional names with automatic Scholar name resolution",
-            "Settings UI polish: refined sidebar colors for light/dark mode and clearer settings copy"
+            "Public releases are now signed with Apple Developer ID and notarized by Apple",
+            "DMG installs now support the standard drag-to-Applications flow without Terminal trust workarounds",
+            "Settings now include clearer recovery paths for launch-at-login and notification permissions",
+            "Menu bar startup behavior is more robust when macOS or third-party menu managers delay status item creation"
         ],
-        description: "This release focuses on efficiency and UX polish by lowering unnecessary Scholar requests while making profile onboarding and settings interaction smoother.",
+        description: "This release focuses on distribution trust and first-run reliability, making CiteBar easier for non-technical users to download, install, and keep running.",
         technicalNotes: [
-            "Added CitationManager snapshot APIs to fetch display name + metrics from a single Scholar page request",
-            "Added staleness-aware startup refresh policy helpers and integrated them into launch flow",
-            "New profile priming now writes metrics for the added profile without forcing an immediate full refresh",
-            "Added fallback-safe Scholar name extraction from profile header, og:title, and page title",
-            "Extended test suite for startup refresh policy branches and profile snapshot/display-name parsing"
+            "Added Developer ID signing and Apple notarization support for local and GitHub Actions releases",
+            "Added explicit signing validation for the app bundle, main executable, Sparkle framework binary, nested Sparkle helpers, and DMG container",
+            "Added notarization polling, submission log capture, diagnostics artifacts, and stapled-ticket verification",
+            "Added Apple Events entitlement and usage description for the optional launch-at-login fallback path",
+            "Updated distribution documentation, release workflow checks, and website messaging for the notarized DMG release path"
         ]
     )
     

--- a/scripts/create-info-plist.sh
+++ b/scripts/create-info-plist.sh
@@ -51,6 +51,8 @@ cat > "$1" << EOF
     <true/>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2025 CiteBar. All rights reserved.</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>CiteBar uses Apple Events only to manage the optional launch-at-login setting on older macOS configurations.</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/scripts/extract-release-notes.swift
+++ b/scripts/extract-release-notes.swift
@@ -62,6 +62,7 @@ func extractVersion(from content: String) -> String {
 let version = extractVersion(from: content)
 let highlights = extractArray(from: content, arrayName: "highlights")
 let description = extractDescription(from: content)
+let technicalNotes = extractArray(from: content, arrayName: "technicalNotes")
 
 if format == "html" {
     // Generate HTML for Sparkle appcast
@@ -78,6 +79,14 @@ if format == "html" {
         markdown += "- ✨ \(highlight)\n"
     }
     markdown += "\n\(description)\n\n"
+
+    if !technicalNotes.isEmpty {
+        markdown += "### Technical Improvements\n\n"
+        for note in technicalNotes {
+            markdown += "- \(note)\n"
+        }
+        markdown += "\n"
+    }
     
     markdown += """
     ## Installation

--- a/scripts/notarize-dmg.sh
+++ b/scripts/notarize-dmg.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+set -euo pipefail
+
+DMG_FILE="${1:-${DMG_FILE:-}}"
+
+if [ -z "$DMG_FILE" ]; then
+    echo "Usage: scripts/notarize-dmg.sh path/to/CiteBar.dmg"
+    exit 1
+fi
+
+if [ ! -f "$DMG_FILE" ]; then
+    echo "Error: DMG not found: $DMG_FILE"
+    exit 1
+fi
+
+LOG_ROOT="${NOTARY_LOG_DIR:-dist/notary-logs}"
+DMG_BASENAME=$(basename "$DMG_FILE")
+DMG_STEM="${DMG_BASENAME%.dmg}"
+RUN_STAMP=$(date -u +"%Y%m%dT%H%M%SZ")
+RUN_LOG_DIR="$LOG_ROOT/$DMG_STEM-$RUN_STAMP"
+mkdir -p "$RUN_LOG_DIR"
+
+NOTARY_ARGS=()
+if [ -n "${NOTARY_PROFILE:-}" ]; then
+    NOTARY_ARGS+=(--keychain-profile "$NOTARY_PROFILE")
+else
+    if [ -z "${APPLE_ID:-}" ] || [ -z "${APPLE_TEAM_ID:-}" ] || [ -z "${APP_SPECIFIC_PASSWORD:-}" ]; then
+        echo "Error: set NOTARY_PROFILE, or set APPLE_ID, APPLE_TEAM_ID, and APP_SPECIFIC_PASSWORD."
+        exit 1
+    fi
+    NOTARY_ARGS+=(--apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APP_SPECIFIC_PASSWORD")
+fi
+
+run_notary_log() {
+    local submission_id="$1"
+    local log_path="$RUN_LOG_DIR/submission-log.json"
+
+    echo "Fetching Apple notary submission log..."
+    if xcrun notarytool log "${NOTARY_ARGS[@]}" "$submission_id" "$log_path"; then
+        echo "Saved Apple notary submission log: $log_path"
+    else
+        echo "Apple notary submission log is not available yet."
+        echo "Saved log attempt output path for follow-up: $log_path"
+    fi
+}
+
+echo "Submitting $DMG_FILE for notarization..."
+SUBMISSION_JSON=$(xcrun notarytool submit "$DMG_FILE" "${NOTARY_ARGS[@]}" --output-format json)
+echo "$SUBMISSION_JSON"
+printf "%s\n" "$SUBMISSION_JSON" > "$RUN_LOG_DIR/submit.json"
+
+SUBMISSION_ID=$(printf "%s" "$SUBMISSION_JSON" | plutil -extract id raw -o - - 2>/dev/null || true)
+
+if [ -z "$SUBMISSION_ID" ]; then
+    echo "Error: could not read notary submission ID."
+    echo "Notary diagnostics directory: $RUN_LOG_DIR"
+    exit 1
+fi
+
+printf "%s\n" "$SUBMISSION_ID" > "$RUN_LOG_DIR/submission-id.txt"
+ln -sfn "$(basename "$RUN_LOG_DIR")" "$LOG_ROOT/latest"
+
+POLL_INTERVAL_SECONDS="${NOTARY_POLL_INTERVAL_SECONDS:-30}"
+TIMEOUT_SECONDS="${NOTARY_TIMEOUT_SECONDS:-1800}"
+ELAPSED_SECONDS=0
+STATUS="In Progress"
+POLL_COUNT=0
+
+echo "Waiting for notarization result for submission: $SUBMISSION_ID"
+while [ "$STATUS" = "In Progress" ] && [ "$ELAPSED_SECONDS" -lt "$TIMEOUT_SECONDS" ]; do
+    sleep "$POLL_INTERVAL_SECONDS"
+    ELAPSED_SECONDS=$((ELAPSED_SECONDS + POLL_INTERVAL_SECONDS))
+    POLL_COUNT=$((POLL_COUNT + 1))
+
+    INFO_JSON=$(xcrun notarytool info "$SUBMISSION_ID" "${NOTARY_ARGS[@]}" --output-format json)
+    STATUS=$(printf "%s" "$INFO_JSON" | plutil -extract status raw -o - - 2>/dev/null || true)
+    INFO_PATH=$(printf "%s/poll-%03d.json" "$RUN_LOG_DIR" "$POLL_COUNT")
+    printf "%s\n" "$INFO_JSON" > "$INFO_PATH"
+    printf "%s\n" "$INFO_JSON" > "$RUN_LOG_DIR/latest-info.json"
+
+    echo "[$ELAPSED_SECONDS/$TIMEOUT_SECONDS seconds] Notarization status: ${STATUS:-unknown}"
+done
+
+if [ "$STATUS" = "In Progress" ]; then
+    echo "Notarization is still in progress after $TIMEOUT_SECONDS seconds."
+    run_notary_log "$SUBMISSION_ID" || true
+    echo "Resume checking with:"
+    if [ -n "${NOTARY_PROFILE:-}" ]; then
+        echo "  xcrun notarytool info $SUBMISSION_ID --keychain-profile \"$NOTARY_PROFILE\""
+        echo "  xcrun notarytool log $SUBMISSION_ID --keychain-profile \"$NOTARY_PROFILE\" \"$RUN_LOG_DIR/submission-log.json\""
+    else
+        echo "  xcrun notarytool info $SUBMISSION_ID --apple-id \"$APPLE_ID\" --team-id \"$APPLE_TEAM_ID\" --password \"<app-specific-password>\""
+        echo "  xcrun notarytool log $SUBMISSION_ID --apple-id \"$APPLE_ID\" --team-id \"$APPLE_TEAM_ID\" --password \"<app-specific-password>\" \"$RUN_LOG_DIR/submission-log.json\""
+    fi
+    echo "Notary diagnostics directory: $RUN_LOG_DIR"
+    exit 124
+fi
+
+if [ "$STATUS" != "Accepted" ]; then
+    echo "Notarization failed with status: ${STATUS:-unknown}"
+    run_notary_log "$SUBMISSION_ID" || true
+    echo "Inspect the detailed log with:"
+    if [ -n "${NOTARY_PROFILE:-}" ]; then
+        echo "  xcrun notarytool log $SUBMISSION_ID --keychain-profile \"$NOTARY_PROFILE\""
+    else
+        echo "  xcrun notarytool log $SUBMISSION_ID --apple-id \"$APPLE_ID\" --team-id \"$APPLE_TEAM_ID\" --password \"<app-specific-password>\""
+    fi
+    echo "Notary diagnostics directory: $RUN_LOG_DIR"
+    exit 1
+fi
+
+run_notary_log "$SUBMISSION_ID" || true
+
+echo "Stapling notarization ticket..."
+xcrun stapler staple "$DMG_FILE"
+xcrun stapler validate "$DMG_FILE"
+
+echo "Checking Gatekeeper assessment..."
+spctl -a -vvv -t open --context context:primary-signature "$DMG_FILE"
+
+echo "Notary diagnostics directory: $RUN_LOG_DIR"

--- a/scripts/sign-app.sh
+++ b/scripts/sign-app.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_BUNDLE="${1:-dist/CiteBar.app}"
+PRODUCT_NAME="${2:-CiteBar}"
+SIGN_IDENTITY="${SIGN_IDENTITY:-${DEVELOPER_ID_APPLICATION:-"-"}}"
+ENTITLEMENTS_FILE="${ENTITLEMENTS_FILE:-CiteBar.entitlements}"
+
+if [ ! -d "$APP_BUNDLE" ]; then
+    echo "Error: app bundle not found: $APP_BUNDLE"
+    exit 1
+fi
+
+sign_path() {
+    local path="$1"
+    local use_entitlements="${2:-false}"
+
+    if [ ! -e "$path" ]; then
+        return 0
+    fi
+
+    if [ "$SIGN_IDENTITY" = "-" ]; then
+        if [ "$use_entitlements" = "true" ] && [ -f "$ENTITLEMENTS_FILE" ]; then
+            codesign --force --sign - --entitlements "$ENTITLEMENTS_FILE" "$path"
+        else
+            codesign --force --sign - "$path"
+        fi
+    else
+        if [ "$use_entitlements" = "true" ] && [ -f "$ENTITLEMENTS_FILE" ]; then
+            codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" --entitlements "$ENTITLEMENTS_FILE" "$path"
+        else
+            codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$path"
+        fi
+    fi
+}
+
+verify_path() {
+    local path="$1"
+
+    if [ ! -e "$path" ]; then
+        return 0
+    fi
+
+    codesign --verify --strict --verbose=4 "$path"
+}
+
+echo "Signing $APP_BUNDLE"
+if [ "$SIGN_IDENTITY" = "-" ]; then
+    echo "Using ad-hoc signing identity"
+else
+    echo "Using signing identity: $SIGN_IDENTITY"
+fi
+
+xattr -cr "$APP_BUNDLE"
+
+SPARKLE_FRAMEWORK="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+if [ -d "$SPARKLE_FRAMEWORK" ]; then
+    sign_path "$SPARKLE_FRAMEWORK/Versions/B/XPCServices/Downloader.xpc"
+    sign_path "$SPARKLE_FRAMEWORK/Versions/B/XPCServices/Installer.xpc"
+    sign_path "$SPARKLE_FRAMEWORK/Versions/B/Autoupdate"
+    sign_path "$SPARKLE_FRAMEWORK/Versions/B/Updater.app"
+    sign_path "$SPARKLE_FRAMEWORK"
+    sign_path "$SPARKLE_FRAMEWORK/Versions/B/Sparkle"
+fi
+
+sign_path "$APP_BUNDLE" true
+sign_path "$APP_BUNDLE/Contents/MacOS/$PRODUCT_NAME" true
+
+verify_path "$APP_BUNDLE/Contents/MacOS/$PRODUCT_NAME"
+if [ -d "$SPARKLE_FRAMEWORK" ]; then
+    verify_path "$SPARKLE_FRAMEWORK/Versions/B/Sparkle"
+fi
+codesign --verify --strict --deep --verbose=2 "$APP_BUNDLE"
+codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1 | grep -E "Authority=|TeamIdentifier=|Runtime|Timestamp" || true

--- a/website/index.html
+++ b/website/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CiteBar | Google Scholar Citation Tracker for macOS</title>
-  <meta name="description" content="CiteBar is a native macOS menu bar app for tracking Google Scholar citations. Check updates at a glance, open profiles in one click, and see recent 30-day changes.">
+  <meta name="description" content="CiteBar is a notarized native macOS menu bar app for tracking Google Scholar citations. Check updates at a glance, open profiles in one click, and see recent 30-day changes.">
   <meta name="keywords" content="CiteBar, Google Scholar, citation tracker, h-index, i10-index, macOS menu bar app, academic tool">
   <meta name="author" content="CiteBar Contributors">
   <meta name="robots" content="index,follow,max-image-preview:large">
@@ -12,13 +12,13 @@
 
   <meta property="og:type" content="website">
   <meta property="og:title" content="CiteBar | Google Scholar Citation Tracker for macOS">
-  <meta property="og:description" content="Track Google Scholar citations from your menu bar. Check updates at a glance, open profiles in one click, and see recent 30-day changes.">
+  <meta property="og:description" content="Track Google Scholar citations from your menu bar with a notarized macOS app. Check updates at a glance, open profiles in one click, and see recent 30-day changes.">
   <meta property="og:url" content="https://www.citebar.org/">
   <meta property="og:image" content="https://www.citebar.org/assets/logo-512.png">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="CiteBar | Google Scholar Citation Tracker for macOS">
-  <meta name="twitter:description" content="Track Google Scholar citations from your menu bar. Check updates at a glance, open profiles in one click, and see recent 30-day changes.">
+  <meta name="twitter:description" content="Track Google Scholar citations from your menu bar with a notarized macOS app. Check updates at a glance, open profiles in one click, and see recent 30-day changes.">
   <meta name="twitter:image" content="https://www.citebar.org/assets/logo-512.png">
 
   <link rel="icon" type="image/png" sizes="32x32" href="assets/logo-128.png">
@@ -37,7 +37,7 @@
     "name": "CiteBar",
     "applicationCategory": "BusinessApplication",
     "operatingSystem": "macOS 13.0+",
-    "description": "A native macOS menu bar application that tracks Google Scholar citation metrics, opens profiles quickly, and shows recent 30-day changes.",
+    "description": "A notarized native macOS menu bar application that tracks Google Scholar citation metrics, opens profiles quickly, and shows recent 30-day changes.",
     "softwareVersion": "Dynamic (latest release)",
     "downloadUrl": "https://github.com/hichipli/CiteBar/releases/latest",
     "offers": {
@@ -78,7 +78,7 @@
         "name": "Why does macOS show 'CiteBar is damaged and can't be opened'?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "This is usually a Gatekeeper quarantine prompt for non-notarized downloads. Run xattr -cr /Applications/CiteBar.app or allow the app in Privacy & Security."
+        "text": "CiteBar 1.5.0 and later are signed with Apple Developer ID and notarized by Apple. If you see this warning, delete the download and install the latest release from the official GitHub Releases page."
         }
       },
       {
@@ -86,7 +86,7 @@
         "name": "What if macOS says 'Cannot verify developer'?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Right-click CiteBar.app in Applications, select Open, then confirm Open again in the dialog."
+        "text": "Current releases should show a verified Developer ID prompt. If macOS cannot verify the developer, make sure you downloaded version 1.5.0 or later from the official GitHub Releases page."
         }
       },
       {
@@ -94,7 +94,7 @@
         "name": "What if I am on 1.3.x or 1.4.1 and auto-update fails?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Manually install the latest DMG once. After moving to 1.4.4 or later, automatic updates should work normally."
+        "text": "Manually install the latest DMG once. After moving to a current release, automatic updates should work normally."
         }
       },
       {
@@ -154,7 +154,7 @@
             <p class="subhead">
               CiteBar brings Google Scholar updates directly to your menu bar. 
               Check your h-index at a glance, jump to profiles instantly, and monitor 30-day citation growth. 
-              Open source, free, and designed specifically for macOS.
+              Open source, free, notarized by Apple, and designed specifically for macOS.
             </p>
             <div class="hero-actions">
               <a id="download-button" class="btn btn-primary" href="https://github.com/hichipli/CiteBar/releases/latest">Download Free</a>
@@ -168,11 +168,11 @@
               </div>
               <div class="trust-item">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>
-                <span>Open Source MIT</span>
+                <span>Apple Notarized</span>
               </div>
               <div class="trust-item">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
-                <span>macOS 13.0+</span>
+                <span>Open Source MIT</span>
               </div>
             </div>
           </div>
@@ -251,7 +251,7 @@
       <div class="section-inner">
         <div class="section-header reveal">
           <h2 class="section-title">Get started in seconds.</h2>
-          <p class="section-desc">Download, move to Applications, and add your Scholar profile.</p>
+          <p class="section-desc">Download the notarized DMG, move CiteBar to Applications, and add your Scholar profile.</p>
         </div>
 
         <div class="install-container reveal">
@@ -260,7 +260,7 @@
               <div class="step-num">1</div>
               <div class="step-content">
                 <h4>Download CiteBar</h4>
-                <p>Get the latest universal DMG from GitHub Releases.</p>
+                <p>Get the latest universal, notarized DMG from GitHub Releases.</p>
               </div>
             </div>
             <div class="step">
@@ -273,39 +273,22 @@
             <div class="step">
               <div class="step-num">3</div>
               <div class="step-content">
-                <h4>Fix first-launch block (if prompted)</h4>
-                <p>Because the app is open-source and not notarized by Apple, macOS might block it initially. Run this command in your Terminal to allow it:</p>
-                <div class="terminal-box">
-                  <div class="terminal-header">
-                    <div class="mac-btn close"></div>
-                    <div class="mac-btn min"></div>
-                    <div class="mac-btn max"></div>
-                  </div>
-                  <div class="terminal-body">
-                    <span class="prompt">~ %</span>
-                    <code id="quarantine-command">xattr -cr /Applications/CiteBar.app</code>
-                    <button id="copy-command-btn" class="copy-btn" type="button" aria-label="Copy command">
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
-                      <span class="copy-text-default">Copy</span>
-                      <span class="copy-text-success">Copied!</span>
-                    </button>
-                  </div>
-                </div>
-                <p id="copy-status" class="copy-status" aria-live="polite"></p>
+                <h4>Open CiteBar</h4>
+                <p>Launch CiteBar from Applications. macOS may show a standard first-launch confirmation for downloaded apps.</p>
               </div>
             </div>
             <div class="step">
               <div class="step-num">4</div>
               <div class="step-content">
-                <h4>Launch & Add Profile</h4>
-                <p>Open the app, paste a Google Scholar profile URL into Settings, and you're all set.</p>
+                <h4>Add Profile</h4>
+                <p>Paste a Google Scholar profile URL into Settings, choose your refresh schedule, and you're all set.</p>
               </div>
             </div>
           </div>
           
           <div class="install-help">
-            <h4>Alternative Troubleshooting</h4>
-            <p>If you see <strong>"Cannot verify developer"</strong> instead, right-click <code>CiteBar.app</code> in your Applications folder, choose <strong>Open</strong>, then click <strong>Open</strong> again in the popup.</p>
+            <h4>Need Help?</h4>
+            <p>Version <code>1.5.0+</code> is signed and notarized. If macOS still blocks launch, delete the download and install the latest DMG again from the official release page.</p>
             <a href="https://github.com/hichipli/CiteBar/blob/main/DISTRIBUTION.md" target="_blank" rel="noreferrer" class="link-arrow">Read full distribution guide <span>→</span></a>
           </div>
         </div>
@@ -337,21 +320,21 @@
           <details class="faq-item" name="faq">
             <summary>Why does macOS say "CiteBar is damaged and can't be opened"?</summary>
             <div class="faq-content">
-              <p>This is a standard macOS Gatekeeper quarantine warning that occurs for direct, non-notarized software downloads. To fix it, simply open Terminal, run <code>xattr -cr /Applications/CiteBar.app</code>, and then open the app again normally.</p>
+              <p>CiteBar <code>1.5.0+</code> is signed with Apple Developer ID and notarized by Apple. If you see this warning on a current release, delete the downloaded DMG and install the latest release again from the official GitHub Releases page. Older pre-<code>1.5.0</code> builds may show this warning on newer macOS versions.</p>
             </div>
           </details>
 
           <details class="faq-item" name="faq">
             <summary>What if macOS says "Cannot verify developer"?</summary>
             <div class="faq-content">
-              <p>Open your Applications folder, right-click (or Control-click) on <code>CiteBar.app</code>, select <strong>Open</strong> from the context menu, and then click <strong>Open</strong> again in the dialog box.</p>
+              <p>Current releases should show a verified Developer ID prompt. If macOS cannot verify the developer, make sure you downloaded CiteBar <code>1.5.0+</code> from the official GitHub Releases page.</p>
             </div>
           </details>
 
           <details class="faq-item" name="faq">
             <summary>I am on version 1.3.x or 1.4.1 and auto-update fails. What should I do?</summary>
             <div class="faq-content">
-              <p>Manually download and install the latest DMG from GitHub this one time. After you have upgraded to version <code>1.4.4+</code> or newer, the in-app automatic update feature will work normally for future releases.</p>
+              <p>Manually download and install the latest DMG from GitHub this one time. After you have upgraded to a current release, the in-app automatic update feature should work normally for future releases.</p>
             </div>
           </details>
 


### PR DESCRIPTION
Prepares CiteBar 1.5.0 with Developer ID signing, Apple notarization, signed DMG distribution, CI dry-run release validation, and updated user-facing install guidance.